### PR TITLE
Remove Terrascan

### DIFF
--- a/.github/workflows/terraform_checks.yml
+++ b/.github/workflows/terraform_checks.yml
@@ -51,25 +51,6 @@ jobs:
       - name: TFLint validate
         run: tflint
 
-  terrascan:
-    name: Terrascan
-
-    needs: terraform_lint
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Check out the codebase
-        uses: actions/checkout@v5
-
-      - name: Run Terrascan
-        uses: tenable/terrascan-action@main
-        with:
-          iac_type: 'terraform'
-          iac_dir: ./production
-          config_path: ./production/.terrascan.toml
-          non_recursive: true
-          verbose: true
-
   kics:
     name: KICS
 

--- a/production/.terrascan.toml
+++ b/production/.terrascan.toml
@@ -1,6 +1,0 @@
-[severity]
-  level = "high"
-[rules]
-    skip-rules = [
-        "AC_AWS_0207"
-    ]


### PR DESCRIPTION
Terrascan seems to be abandon-ware now, and it's causing all my PRs to fail their checks. Removing it for now.